### PR TITLE
Remove doctest include cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,5 +32,4 @@ target_link_libraries(canary_lib
     spdlog::spdlog
 )
 
-include(doctest)
 add_subdirectory(3rd)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,3 @@ set_target_properties(canary-lib-tests
     PROPERTIES
       RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/"
 )
-
-doctest_discover_tests(canary-lib-tests
-                      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/canary-lib)


### PR DESCRIPTION
Remove doctest cmake file as we are running the binary generated and
not the cmake files.

Signed-off-by: Renato Foot <costallat@hotmail.com>